### PR TITLE
Update rfc5077-client.c

### DIFF
--- a/rfc5077-client.c
+++ b/rfc5077-client.c
@@ -159,7 +159,7 @@ resultinfo_display(struct resultinfo *result) {
 
   n = BIO_get_mem_data(mem, &buf);
   buf[n-1] = '\0';
-  end(buf);
+  end("%s",buf);
   BIO_free(mem);
   return;
 


### PR DESCRIPTION
Send "%s" as first argument of end(...) to fix following error:
rfc5077-client.c: In function 'resultinfo_display':
rfc5077-client.c:162:3: error: format not a string literal and no format arguments

Local gcc version 4.5.4
