### PR TITLE
Modfiy explicit cast to long long

### DIFF
--- a/rfc5077-client.c
+++ b/rfc5077-client.c
@@ -391,7 +391,7 @@ main(int argc, char * const argv[]) {
 
   /* Build file name */
   n = snprintf(name, sizeof(name),
-	       "rfc5077-output-%lu", (unsigned long)now);
+	       "rfc5077-output-%llu", (unsigned long long)now);
   if (n == -1 || n >= sizeof(name))
     fail("Not possible...");
   for (i = 1; i < argc; i++) {


### PR DESCRIPTION
this PR modifies the sprintf cast from long to long long. This is because in 32bit architecture, the number will wrap around after int overflow, which will ultimately delete some of the existing files.